### PR TITLE
Fix claim button not appearing

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -63,7 +63,8 @@ function Dashboard() {
           <p><strong>VIN:</strong> {req.vin}</p>
           <p><strong>Stock:</strong> {req.stock}</p>
           <p><strong>Phone:</strong> {req.phone}</p>
-          {req.status === 'waiting' && (
+          <p><strong>Status:</strong> {req.status}</p>
+          {req.status?.toLowerCase().trim() === 'waiting' && (
             <button onClick={() => handleClaim(req.id)}>Claim Task</button>
           )}
           {req.status === 'in-progress' && (


### PR DESCRIPTION
## Summary
- show request status and normalize status comparison for Claim button
- add missing `Dashboard.css` so build succeeds

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a43156008833198c73be014353c3b