### PR TITLE
Improve status check in dashboard

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -64,7 +64,8 @@ function Dashboard() {
           <p><strong>Stock:</strong> {req.stock}</p>
           <p><strong>Phone:</strong> {req.phone}</p>
           <p><strong>Status:</strong> {req.status}</p>
-          {req.status?.toLowerCase().trim() === 'waiting' && (
+          <p><strong>[Debug] Raw Status:</strong> "{req.status}"</p>
+          {req.status?.toString().toLowerCase().trim() === 'waiting' && (
             <button onClick={() => handleClaim(req.id)}>Claim Task</button>
           )}
           {req.status === 'in-progress' && (


### PR DESCRIPTION
## Summary
- display the raw status value for debugging
- ensure the "Claim Task" button renders even if status has odd casing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a4531eb48833198f44160813cbd57