### PR TITLE
Add startTime to Firebase requests

### DIFF
--- a/src/UploadPage.jsx
+++ b/src/UploadPage.jsx
@@ -41,11 +41,13 @@ export default function UploadPage() {
       const db = getDatabase(app);
       const reqRef = ref(db, 'testDriveRequests');
 
+      const startTime = Date.now();
       const newRequest = {
         vin,
         stock,
         phone,
-        timestamp: Date.now(),
+        timestamp: startTime,
+        startTime,
         status: "waiting",
         revealed: false,
         idUploaded,


### PR DESCRIPTION
## Summary
- include a `startTime` field when submitting a request

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a5e576e788331967be4b4a4259b10