### PR TITLE
Show Test Drive label only for claimed requests

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -93,7 +93,9 @@ function Dashboard() {
           </tr>
         </thead>
         <tbody>
-          {requests.map(({ id, startTime, vin, stock, status, duration }) => (
+          {requests.map((task) => {
+            const { id, startTime, vin, stock, status, duration } = task;
+            return (
             <tr key={id}>
               <td>{startTime ? new Date(startTime).toLocaleTimeString() : "--"}</td>
               <td>{vin || "--"}</td>
@@ -141,9 +143,10 @@ function Dashboard() {
                 )}
               </td>
               <td>{duration || "—"}</td>
-              <td>Test Drive</td>
+              <td>{task.assistant ? "Test Drive" : ""}</td>
             </tr>
-          ))}
+            );
+          })}
         </tbody>
       </table>
 


### PR DESCRIPTION
## Summary
- update Dashboard's table row rendering
- hide "Test Drive" column unless a task has an assistant assigned

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a67f05a188331bd7747110b18fd80